### PR TITLE
Client-side detections improved

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -148,8 +148,8 @@ CreateThread(function() 	-- Spawned car --
                         if plate == BlockedPlate then
                             if DriverSeat == ped then
                                 DeleteVehicle(veh)
-                                TriggerServerEvent("qb-anticheat:server:banPlayer", "Cheating")
                                 TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Cheat detected!", "red", "** @everyone " ..GetPlayerName(player).. "** has been banned for cheating (Sat as driver in spawned vehicle with license plate **"..BlockedPlate..")**")
+                                TriggerServerEvent("qb-anticheat:server:banPlayer", "Cheating")
                             end
                         end
                     end
@@ -201,16 +201,58 @@ RegisterNetEvent('qb-anticheat:client:NonRegisteredEventCalled', function(reason
     TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player banned! (Not really of course, this is a test duuuhhhh)", "red", "** @everyone " ..GetPlayerName(player).. "** has event **"..CalledEvent.."tried to trigger (LUA injector!)")
 end)
 
-if Config.Antiresourcestop then
+Citizen.CreateThread(function()
+    while true do 
+        Citizen.Wait(5000)
+        if Config.AntiGodMode.Check1 then
+            if not IsPlayerDead(PlayerId()) then
+                if GetPlayerInvincible_2(PlayerId()) then
+                    TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! GodMode", "red", "** @everyone " ..GetPlayerName(player).. "** Tried to use GodMode. (Method 1)")
+                    flags = flags + 1
+                end
+            end
+        end
+        if Config.AntiGodMode.Check2 then
+            if not IsPlayerDead(PlayerId()) then
+                local bull, coll, steam, p7, dr = GetEntityProofs(PlayerPedId())
+                if bull ~= 0 and coll ~= 0 and steam ~= 0 and p7 ~= 0 and dr ~= 0 then
+                    TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! GodMode", "red", "** @everyone " ..GetPlayerName(player).. "** Tried to use GodMode. (Method 2)")
+                    flags = flags + 1
+                end
+            end
+        end
+        if Config.AntiDUI then
+            local duis = {
+                {texturedict = "HydroMenu", texture = "HydroMenuHeader", name = "Hydro"},
+                {texturedict = "John", texture = "John2", name = "Sugar"},
+                {texturedict = "fm", texture = "menu_bg", name = "Fallout"},
+                {texturedict = "MM", texture = "menu_bg", name="MetrixMethods Fallout"},
+            }
+            
+            for i, duis in pairs(duis) do
+                if duis.x and duis.y then
+                    if GetTextureResolution(duis.texturedict, duis.texture).x == duis.x and GetTextureResolution(duis.texturedict, duis.texture).y == duis.y then
+                        TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! Mod Menu injection", "red", "** @everyone " ..GetPlayerName(player).. "** tried to inject the following mod menu: **`"..duis.name.."`")
+                        flags = flags + 1
+                    end
+                else 
+                    if GetTextureResolution(duis.texturedict, duis.texture).x ~= 4.0 then
+                        TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! Mod Menu injection", "red", "** @everyone " ..GetPlayerName(player).. "** tried to inject the following mod menu: **`"..duis.name.."`")
+                        flags = flags + 1
+                    end
+                end
+            end
+        end
 
-AddEventHandler("onResourceStop", function(res, source)
-        local source = src
-        if res == GetCurrentResourceName() then
-print(GetPlayerName(src) .. "Was kickaed for stoping" .. res)
-DropPlayer(src, "Stoping Resources.")
-            Citizen.Wait(100)
-            CancelEvent()
-        end 
+        if Config.AntiMenuStyles then
+            if HasStreamedTextureDictLoaded('fm') or HasStreamedTextureDictLoaded('rampage_tr_main') or HasStreamedTextureDictLoaded('MenyooExtras') then
+                TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! AntiMenuStyles injection", "red", "** @everyone " ..GetPlayerName(player).. "** tried to inject a menu with suspicious styles..")
+                flags = flags + 1
+            end
+            if HasStreamedTextureDictLoaded('shopui_title_graphics_franklin') or HasStreamedTextureDictLoaded('deadline') then
+                TriggerServerEvent("qb-log:server:CreateLog", "anticheat", "Player flagged! AntiMenuStyles injection", "red", "** @everyone " ..GetPlayerName(player).. "** tried to inject a menu with suspicious styles..")
+                flags = flags + 1
+            end
+        end
+    end
 end)
-
-end

--- a/config.lua
+++ b/config.lua
@@ -7,8 +7,6 @@ Config.FlagsForBan = 5
 Config.SuperJumpLength = 20.0
 Config.MaxSpeed = 13 
 
-Config.Antiresourcestop = true
-
 -- Set group --
 Config.Group = "user"
 
@@ -17,6 +15,17 @@ Config.BlacklistedPlates = {
     "BRUTAN",
 }
 
+-- AntiGodMode
+Config.AntiGodMode = {
+    Check1 = true, -- Method 1
+    Check2 = true -- Method 2
+}
+
+-- AntiDUIMenu
+Config.AntiDUI = true
+
+-- AntiMenuStyles (Blocking weird menu styles, which are not used in scripts)
+Config.AntiMenuStyles = true
 
 Config.BlacklistedEvents = {
     '211ef2f8-f09c-4582-91d8-087ca2130157',


### PR DESCRIPTION
I improved client side detections. I added an antigodmode system, and AntiDUIMenu system, which can detect some lua mod menus, and a menu style checker. I removed antiresourcestop cause it doesn't do anything except blocking **admins** from restarting qb-anticheat, but it didn't block any resource stopper cheats, resource stopper cheats doesn't trigger onResourceStop and onClientResourceStop events.